### PR TITLE
Fix EventHandler not being unsubscribed

### DIFF
--- a/src/GridLog.cs
+++ b/src/GridLog.cs
@@ -15,6 +15,11 @@ namespace Serilog.Sinks.WinForms
             LogGridView.Font = this.Font;
 
             WindFormsSink.GridLogSink.OnGridLogReceived += GridLogSink_OnGridLogReceived;
+
+            HandleDestroyed += ( handler, args ) =>
+            {
+                WindFormsSink.GridLogSink.OnGridLogReceived -= GridLogSink_OnGridLogReceived;
+            };
         }
 
         private void GridLogSink_OnGridLogReceived(GridLogEvent logEvent)

--- a/src/JsonLogTextBox.cs
+++ b/src/JsonLogTextBox.cs
@@ -32,6 +32,11 @@ namespace Serilog.Sinks.WinForms
             TxtLogControl.ForeColor = this.ForeColor;
             TxtLogControl.BackColor = this.BackColor;
             WindFormsSink.JsonTextBoxSink.OnLogReceived += JsonTextBoxSinkOnLogReceived;
+
+            HandleDestroyed += ( handler, args ) =>
+            {
+                WindFormsSink.JsonTextBoxSink.OnLogReceived -= JsonTextBoxSinkOnLogReceived;
+            };
         }
 
         private void JsonTextBoxSinkOnLogReceived(string context, string str)

--- a/src/RichTextBoxLogControl.cs
+++ b/src/RichTextBoxLogControl.cs
@@ -12,6 +12,11 @@ namespace Serilog.Sinks.WinForms
         {
             InitializeComponent();
             WindFormsSink.SimpleTextBoxSink.OnLogReceived += SimpleTextBoxSinkOnLogReceived;
+
+            HandleDestroyed += ( sender, args ) =>
+            {
+                WindFormsSink.SimpleTextBoxSink.OnLogReceived -= SimpleTextBoxSinkOnLogReceived;
+            };
         }
 
         private void SimpleTextBoxSinkOnLogReceived(string context, string str)

--- a/src/SimpleLogTextBox.cs
+++ b/src/SimpleLogTextBox.cs
@@ -35,6 +35,11 @@ namespace Serilog.Sinks.WinForms
             _isContextConfigured = !string.IsNullOrEmpty(this.ForContext);
 
             WindFormsSink.SimpleTextBoxSink.OnLogReceived += SimpleTextBoxSinkOnLogReceived;
+
+            HandleDestroyed += ( handler, args ) =>
+            {
+                WindFormsSink.SimpleTextBoxSink.OnLogReceived -= SimpleTextBoxSinkOnLogReceived;
+            };
         }
 
         private void SimpleTextBoxSinkOnLogReceived(string context, string str)

--- a/src/TransparentSimpleLogTextBox.cs
+++ b/src/TransparentSimpleLogTextBox.cs
@@ -21,6 +21,12 @@ namespace Serilog.Sinks.WinForms
 
             BackColor = Color.Transparent;
             WindFormsSink.SimpleTextBoxSink.OnLogReceived += SimpleTextBoxSinkOnLogReceived;
+
+            HandleDestroyed += ( handler, args ) =>
+            {
+                WindFormsSink.SimpleTextBoxSink.OnLogReceived -= SimpleTextBoxSinkOnLogReceived;
+            };
+
             this.Multiline = true;
         }
 


### PR DESCRIPTION
Added an eventhandler to unsubscribe from the LogReceived handler

When having multiple log-controls and closing one of the log-controls, the disposed log-control is still subscribed to the event handler. The eventhandler still tries to access the already disposed object. 

To overcome this issue, I added a Control.HandleDestroyed event to all log-controls to unsubscribe from the LogReceived handler
